### PR TITLE
fix: ItemCategoryType enum values don't match Paypal API

### DIFF
--- a/src/data/orders.rs
+++ b/src/data/orders.rs
@@ -231,14 +231,14 @@ pub enum ItemCategoryType {
     /// Goods that are stored, delivered, and used in their electronic format.
     /// This value is not currently supported for API callers that leverage
     /// the [PayPal for Commerce Platform](https://www.paypal.com/us/webapps/mpp/commerce-platform) product.
-    Digital,
+    DigitalGoods,
     /// A tangible item that can be shipped with proof of delivery.
-    Physical,
+    PhysicalGoods,
 }
 
 impl Default for ItemCategoryType {
     fn default() -> Self {
-        ItemCategoryType::Digital
+        ItemCategoryType::DigitalGoods
     }
 }
 

--- a/src/data/orders.rs
+++ b/src/data/orders.rs
@@ -234,6 +234,9 @@ pub enum ItemCategoryType {
     DigitalGoods,
     /// A tangible item that can be shipped with proof of delivery.
     PhysicalGoods,
+
+    /// A contribution or gift for which no good or service is exchanged, usually to a not for profit organization.
+    Donation,
 }
 
 impl Default for ItemCategoryType {


### PR DESCRIPTION
According to the [docs](https://developer.paypal.com/docs/api/orders/v2/), the enum values should be `DIGITAL_GOODS`, `PHYSICAL_GOODS`, or `DONATION`.